### PR TITLE
Update version and requires in setup.py 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="ReadActor",
-    version="2.0.2-alpha",
+    version="2.0.2-beta",
     author="Qin Gu",
     author_email="guqin7@gmail.com",
     description="A lookup tool for ReadChina project",
@@ -25,6 +25,8 @@ setup(
     include_package_data=True,
     install_requires=[
         "Click",
+        "pandas",
+        "requests"
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,7 @@ setup(
     python_requires=">=3.8",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[
-        "Click",
-        "pandas",
-        "requests"
-    ],
+    install_requires=["Click", "pandas", "requests"],
     entry_points={
         "console_scripts": [
             "readactor = src.scripts.readactor:cli",


### PR DESCRIPTION
Two fixes:
1. Update version so that the earlier PR #83 can pass CI.
2. Add `pandas` and `requests` into `setup.py`. In theory, with this we can remove `pandas` from `pip install ReadActor pandas` and remove `pip install -r requirements.txt`. But we might need to specify the version in `setup.py` and also test it.