### PR TITLE
update version for PYPI uploading

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="ReadActor",
-    version="2.0.3-alpha",
+    version="2.0.3",
     author="Qin Gu",
     author_email="guqin7@gmail.com",
     description="A lookup tool for ReadChina project",


### PR DESCRIPTION
A previous CI run failed due to version number. 

Basing on semantic versioning, if 2.0.3-alpha is already uploaded (but somehow it is not really released on PYPI?), then use 2.0.3 since there is nothing really changed except some code for updating one outdated argument of pandas. 

Isort and Black check passed locally.

See #91